### PR TITLE
Mac/Linux support, replace CertUtil with python md5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.py[co]
+__pycache__/
+patchAndVersionFiles/
+venv/

--- a/README.txt
+++ b/README.txt
@@ -8,5 +8,9 @@ then simply drag and drop your ISO onto the bat file named "DROPYOURISOHERE.bat"
 If everything goes well, the utility will download info on what patches are available and generate a new ISO
 file for you that is the latest version.
 
+(Mac/Linux/Cross-platform notes: run the script from the command line, like this:
+./patch_iso_crossplatform.py '/path/to/Super Smash Bros Melee.iso'
+You need to have python3 and xdelta3 installed)
+
 If things do go wrong, contact Zaik in the Nordic Melee Netplay group or email him at jonatanwaern@gmail.com
 with the error message and he'll get back to you as soon as he can.

--- a/obtain_patch_info.py
+++ b/obtain_patch_info.py
@@ -1,6 +1,10 @@
-from dulwich import porcelain
-from dulwich.repo import Repo
 import sys
+try:
+	from dulwich import porcelain
+	from dulwich.repo import Repo
+	use_dulwich = True
+except ImportError:
+	use_dulwich = False
 
 indent = " "
 def indent_print(*args, **kwargs):
@@ -11,17 +15,44 @@ indent_print("Obtaining 'patch_info.csv', 'version_info.csv' and xdelta files...
 repo_url = "git://github.com/Anutim/NordicMeleeBuild.git"
 repo_dir = "patchAndVersionFiles"
 
-try:
-	repo = Repo(repo_dir)
-	config = repo.get_config()
-	porcelain.pull(repo_dir, repo_url)
-except Exception as e1:
+if use_dulwich:
 	try:
-		porcelain.clone(repo_url, repo_dir)
-	except Exception as e2:
-		indent_print("Failed to clone or pull remote repo using git.")
-		indent_print("Check that you're connected to the internet.")
-		indent_print("Exception dump:")
-		indent_print("Pull failed:", repr(e1))
-		indent_print("Clone failed:", repr(e2))
+		repo = Repo(repo_dir)
+		config = repo.get_config()
+		porcelain.pull(repo_dir, repo_url)
+	except Exception as e1:
+		try:
+			porcelain.clone(repo_url, repo_dir)
+		except Exception as e2:
+			indent_print("Failed to clone or pull remote repo using git.")
+			indent_print("Check that you're connected to the internet.")
+			indent_print("Exception dump:")
+			indent_print("Pull failed:", repr(e1))
+			indent_print("Clone failed:", repr(e2))
+			sys.exit(1)
+else:
+	import os
+	import shutil
+	import subprocess
+	if not shutil.which('git'):
+		indent_print(
+			'Install either the "dulwich" python package or the '
+			'"git" tool to run this utility'
+		)
 		sys.exit(1)
+	indent_print(
+		'Using "git" since the "dulwich" python package is not installed'
+	)
+	if os.path.exists(repo_dir):
+		subprocess.check_output([
+			'git',
+			'pull',
+			repo_url,
+		], cwd=repo_dir)
+	else:
+		subprocess.check_output([
+			'git',
+			'clone',
+			repo_url,
+			repo_dir,
+		])

--- a/patch_iso_crossplatform.py
+++ b/patch_iso_crossplatform.py
@@ -31,12 +31,11 @@ else:
 try:
 	original_iso = sys.argv[1]
 except IndexError:
-	indent_print("run this utility from the command line, like this:".format(sys.argv[0])
+	indent_print("run this utility from the command line, like this:".format(sys.argv[0]))
 	indent_print("")
-	indent_print("{} '/path/to/Super Smash Bros Melee.iso'".format(sys.argv[0])
+	indent_print("{} '/path/to/Super Smash Bros Melee.iso'".format(sys.argv[0]))
 	indent_print("")
 	indent_print("The ISO file can be the Vanilla PAL ISO or Nordic Melee Netplay Build iso (any version, not Melee Netplay Community Build though)")
-	indent_print("")
 	sys.exit(1)
 
 # Confirm existence of the relevant utilities

--- a/patch_iso_crossplatform.py
+++ b/patch_iso_crossplatform.py
@@ -72,7 +72,6 @@ try:
 		python_executable,
 		"read_and_apply_patch_info.py",
 		original_iso,
-		'true' if cert_util_exists else 'false'
 	])
 except subprocess.CalledProcessError:
 	indent_print("Something went wrong while reading or applying patches")

--- a/patch_iso_crossplatform.py
+++ b/patch_iso_crossplatform.py
@@ -31,12 +31,12 @@ else:
 try:
 	original_iso = sys.argv[1]
 except IndexError:
-	indent_print(
-		"To use this, drag-and-drop your Vanilla PAL ISO or Nordic "
-		"Melee Netplay Build iso (any version, not Melee Netplay "
-		"Community Build though)  onto the batch file."
-	)
-	indent_print("(That is, the actual file icon in the folder, not this window.)")
+	indent_print("run this utility from the command line, like this:".format(sys.argv[0])
+	indent_print("")
+	indent_print("{} '/path/to/Super Smash Bros Melee.iso'".format(sys.argv[0])
+	indent_print("")
+	indent_print("The ISO file can be the Vanilla PAL ISO or Nordic Melee Netplay Build iso (any version, not Melee Netplay Community Build though)")
+	indent_print("")
 	sys.exit(1)
 
 # Confirm existence of the relevant utilities

--- a/patch_iso_crossplatform.py
+++ b/patch_iso_crossplatform.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Nordic Melee Netplay Build v1 created by Anutim
+xdelta program created by Josh Macdonald
+Original version of this script created by DRGN.
+Cross-platform conversion by Rainer Koirikivi
+Script version 2.1
+"""
+from __future__ import print_function
+import sys
+if sys.version_info[:2] <= (3, 3):
+	sys.exit("python 3.3 or later is required to run this utility")
+
+import platform
+import subprocess
+import shutil
+
+indent = " "
+def indent_print(*args, **kwargs):
+	print(indent, *args, **kwargs)
+
+python_executable = sys.executable
+
+if platform.system() == 'Windows':
+	is_windows = True
+	xdelta_command = 'xdelta3-x86_64-3.0.10.exe'
+else:
+	is_windows = False
+	xdelta_command = 'xdelta3'
+
+try:
+	original_iso = sys.argv[1]
+except IndexError:
+	indent_print(
+		"To use this, drag-and-drop your Vanilla PAL ISO or Nordic "
+		"Melee Netplay Build iso (any version, not Melee Netplay "
+		"Community Build though)  onto the batch file."
+	)
+	indent_print("(That is, the actual file icon in the folder, not this window.)")
+	sys.exit(1)
+
+# Confirm existence of the relevant utilities
+if not shutil.which(xdelta_command):
+	if is_windows:
+		indent_print("You do not have xDelta on your user path, it SHOULD have been bundled with this script")
+		indent_print("Check that you're executing this script from the correct directory")
+		indent_print('This utility requires "{}" to run'.format(xdelta_command))
+	else:
+		indent_print('Please install "{}" to run this utility'.format(xdelta_command))
+	sys.exit(1)
+
+indent_print("Now attempting to obtain the latest patchinfo file from the server")
+indent_print("Starting python script...")
+try:
+	subprocess.check_call([
+		python_executable,
+		"obtain_patch_info.py",
+	])
+except subprocess.CalledProcessError:
+	indent_print("Failed to obtain the latest patches. If you already have the patchinfo file and")
+	indent_print("the xdelta files, you can continue patching to the version you already have.")
+	indent_print("Would you like to continue with already existing patchinfo?")
+	indent_print("(will fail if you do not have the files)")
+	if input("- (y/n)").lower() in ("n", "no"):
+		sys.exit(1)
+indent_print("Patches succesfully obtained!")
+
+indent_print("Now attempting to read and apply patches")
+
+try:
+	subprocess.check_call([
+		python_executable,
+		"read_and_apply_patch_info.py",
+		original_iso,
+		'true' if cert_util_exists else 'false'
+	])
+except subprocess.CalledProcessError:
+	indent_print("Something went wrong while reading or applying patches")
+	indent_print("This is most likely due to missing patches or incorrect checksums")
+	indent_print("but check the output from the python script for more details.")
+	sys.exit(1)
+
+indent_print("Succesfull! You should now have the latest version of NMNB!")


### PR DESCRIPTION
This PR adds support for running the scripts with Mac and Linux (as long as you have `python3` and the `xdelta3` program).

It also removes the requirement for CertUtil since it seems to me that the same can be accomplished with calculating the md5 sum with python (using `hashlib.md5`). Dulwich requirement is also optional if `git` is installed.

Verified on Mac. Unfortunately, I can't currently verify that things still work on Windows, so that probably needs to be tested before merging. Because of this, I also didn't rewrite `DROPYOURISOHERE.bat` in terms of the new `patch_iso_crossplatform.py`, but doing that should be trivial.
